### PR TITLE
fix docu: int to float for averageTime()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bool ret = Ping.ping(ip_or_host, 10);
 After `Ping.ping()` has been called, the average response time (in milliseconds) can be retrieved with
 
 ```Arduino
-int avg_time_ms = Ping.averageTime();
+float avg_time_ms = Ping.averageTime();
 ```
 ## Fixed in 1.3
 Memory leak bug ( https://github.com/marian-craciunescu/ESP32Ping/issues/4 )


### PR DESCRIPTION
Update README.md : change from int to float for averageTime();
