### PR TITLE
Override ping defaults

### DIFF
--- a/ESP32Ping.cpp
+++ b/ESP32Ping.cpp
@@ -98,7 +98,7 @@ void PingClass::_ping_recv_cb(void *opt, void *resp) {
     // Is it time to end?
     DEBUG_PING("Avg resp time %f ms\n", _avg_time);
     
-    // Done, return to main functiom
+    // Done, return to main function
     esp_schedule();
     
     // just a check ...

--- a/ping.cpp
+++ b/ping.cpp
@@ -94,10 +94,18 @@ static float var_time = 0;
 
 #define PING_ID 0xAFAF
 
+#ifndef PING_DEFAULT_COUNT
 #define PING_DEFAULT_COUNT    10
+#endif
+#ifndef PING_DEFAULT_INTERVAL
 #define PING_DEFAULT_INTERVAL  1
+#endif
+#ifndef PING_DEFAULT_SIZE
 #define PING_DEFAULT_SIZE     32
+#endif
+#ifndef PING_DEFAULT_TIMEOUT
 #define PING_DEFAULT_TIMEOUT   1
+#endif
 
 /*
 * Helper functions

--- a/ping.h
+++ b/ping.h
@@ -1,5 +1,3 @@
-
-
 #ifndef PING_H
 #define PING_H
 #include <Arduino.h>


### PR DESCRIPTION
Related to the suggestion I provided on Issue #25, to be able to override the default values set for ping request configuration:
```
#define PING_DEFAULT_COUNT    10
#define PING_DEFAULT_INTERVAL  1
#define PING_DEFAULT_SIZE     32
#define PING_DEFAULT_TIMEOUT   1
```
Keep the defaults, just add the ability to use other.